### PR TITLE
Bumping Npgsql version to 3.2.7

### DIFF
--- a/src/DoomedDatabases.Postgres/DoomedDatabases.Postgres.csproj
+++ b/src/DoomedDatabases.Postgres/DoomedDatabases.Postgres.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.0" />
-    <PackageReference Include="Npgsql" Version="3.2.5" />
+    <PackageReference Include="Npgsql" Version="3.2.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi, @uhaciogullari !
Great work creating this Nuget package! For me this package is super useful.
Back to topic. With newer Postgres versions (right now I'm using v13) users will encounter this exception when trying to connect to database:
`
Message: 
    System.NotSupportedException : Authentication method not supported (Received: 10)
  Stack Trace: 
    NpgsqlConnector.ParseServerMessage(ReadBuffer buf, BackendMessageCode code, Int32 len, DataRowLoadingMode dataRowLoadingMode, Boolean isPrependedMessage)
    NpgsqlConnector.DoReadMessage(Boolean async, DataRowLoadingMode dataRowLoadingMode, Boolean readingNotifications, Boolean isPrependedMessage)
    NpgsqlConnector.ReadMessage(Boolean async, DataRowLoadingMode dataRowLoadingMode, Boolean readingNotifications)
    NpgsqlConnector.ReadExpecting[T](Boolean async)
    NpgsqlConnector.Authenticate(String username, NpgsqlTimeout timeout, Boolean async, CancellationToken cancellationToken)
    NpgsqlConnector.Open(NpgsqlTimeout timeout, Boolean async, CancellationToken cancellationToken)
    ConnectorPool.AllocateLong(NpgsqlConnection conn, NpgsqlTimeout timeout, Boolean async, CancellationToken cancellationToken)
    NpgsqlConnection.Open(Boolean async, CancellationToken cancellationToken)
    NpgsqlConnection.Open()
    Connection.Execute(String connectionString, String command)
    TestDatabase.Create()
    DatabaseFixture.ctor() line 15
`
Issue is related to outdated Npgsql version which doesn't support some newer authentication features. I bumped Npgsql version to a bit newer one - 3.2.7 (more details here: https://github.com/npgsql/npgsql/releases/tag/v3.2.7). It solved the problem. This change doesn't affect anything else, no changes in compatibility.
I'd appreciate if you accepted this change and also bumped Nuget package version. Thanks!